### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,51 @@
 {
-  "name" : "grunt-modest",
-  "version" : "0.1.2",
-  "description" : "Grunt tasks for working with the modest templating engine",
-  "keywords" : ["modest", "templating", "template", "grunt", "task", "gruntplugin"],
-  "author" : {
-    "name" : "Adam Stallard",
-    "email" : "adam@goalzen.org",
-    "url" : "goalzen.org"
+  "name": "grunt-modest",
+  "version": "0.1.2",
+  "description": "Grunt tasks for working with the modest templating engine",
+  "keywords": [
+    "modest",
+    "templating",
+    "template",
+    "grunt",
+    "task",
+    "gruntplugin"
+  ],
+  "author": {
+    "name": "Adam Stallard",
+    "email": "adam@goalzen.org",
+    "url": "goalzen.org"
   },
-  "directories" : {
-    "test" : "test"
+  "directories": {
+    "test": "test"
   },
-  "dependencies" : {
-    "modest" : ">=1.20.0"
+  "dependencies": {
+    "modest": ">=1.20.0"
   },
-  "devDependencies" : {
-    "grunt-vows-runner" : "*",
-    "grunt-contrib-jshint" : "*",
-    "chai" : "*",
-    "underscore" : "*"
+  "devDependencies": {
+    "grunt-vows-runner": "*",
+    "grunt-contrib-jshint": "*",
+    "chai": "*",
+    "underscore": "*"
   },
-  "peerDependencies" : {
-    "grunt" : "~0.4"
+  "peerDependencies": {
+    "grunt": ">=0.4.0"
   },
-  "license" : {
-    "type" : "MIT",
-    "url" : "https://github.com/goalzen/grunt-modest/blob/master/LICENSE-MIT"
+  "license": {
+    "type": "MIT",
+    "url": "https://github.com/goalzen/grunt-modest/blob/master/LICENSE-MIT"
   },
-  "engines" : {
-    "node" : ">=0.7.1"
+  "engines": {
+    "node": ">=0.7.1"
   },
-  "scripts" : {
-    "test" : "grunt"
+  "scripts": {
+    "test": "grunt"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/goalzen/grunt-modest.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/goalzen/grunt-modest.git"
   },
-  "bugs" : {
-    "url" : "https://github.com/goalzen/grunt-modest/issues"
+  "bugs": {
+    "url": "https://github.com/goalzen/grunt-modest/issues"
   },
-  "homepage" : "https://github.com/goalzen/grunt-modest.git"
+  "homepage": "https://github.com/goalzen/grunt-modest.git"
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
